### PR TITLE
set up CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OUTPUT_DIR ?= $(PWD)/tmp-dir
 .PHONY: build
 build:
 	pipx install cibuildwheel
-	rm -r ./dist
+	rm -r ./dist || true
 	pipx run build --sdist
 
 .PHONY: clean
@@ -22,7 +22,7 @@ full-run:
 
 .PHONY: install
 install:
-	pip install dist/*.tar.gz
+	pipx install --force dist/*.tar.gz
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Ideas for a file content linter:
 * https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml
 * https://github.com/pypa/auditwheel
 * https://github.com/matthew-brett/delocate
+* https://setuptools.pypa.io/en/latest/userguide/entry_point.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+click
 pandas==1.4.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ install_requires = file: requirements.txt
 package_dir =
     =src
 
+[options.entry_points]
+console_scripts =
+    py-artifact-linter = py_artifact_linter.cli:cli
+
 [options.packages.find]
 where = src
 

--- a/src/py_artifact_linter/__init__.py
+++ b/src/py_artifact_linter/__init__.py
@@ -1,4 +1,5 @@
 import pandas as pd
 
+
 def get_df():
     return pd.DataFrame()

--- a/src/py_artifact_linter/cli.py
+++ b/src/py_artifact_linter/cli.py
@@ -1,0 +1,16 @@
+import click
+
+@click.group()
+def cli():
+    """Command group just used to group all others as sub-commands of ``py-artifact-linter``"""
+    pass
+
+@cli.command()
+@click.option("--file", "-f", default=None, help="Comma-delimited list of doppel output files.")
+def check(file: str) -> None:
+    """
+    Check the contents of a distribution.
+    :param file: A file path.
+    """
+    print("running py-artifact-linter")
+    print(file)

--- a/src/py_artifact_linter/cli.py
+++ b/src/py_artifact_linter/cli.py
@@ -1,12 +1,16 @@
 import click
 
+
 @click.group()
 def cli():
     """Command group just used to group all others as sub-commands of ``py-artifact-linter``"""
     pass
 
+
 @cli.command()
-@click.option("--file", "-f", default=None, help="Comma-delimited list of doppel output files.")
+@click.option(
+    "--file", "-f", default=None, help="Comma-delimited list of doppel output files."
+)
 def check(file: str) -> None:
     """
     Check the contents of a distribution.


### PR DESCRIPTION
Contributes to #13.

Adds the scaffolding for exposing this project as a `click` CLI.

Also changes `make install` to use `pipx` instead of `pip` so that development doesn't mess with my local environment.

These tutorials were helpful in setting this up:

* https://click.palletsprojects.com/en/7.x/commands/#callback-invocation
* https://setuptools.pypa.io/en/latest/userguide/entry_point.html
