### PR TITLE
remove testing-only code in CLI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 click
-pandas==1.4.3

--- a/src/py_artifact_linter/__init__.py
+++ b/src/py_artifact_linter/__init__.py
@@ -1,5 +1,2 @@
-import pandas as pd
-
-
-def get_df():
-    return pd.DataFrame()
+# no one should be importing from this package
+__all__ = []


### PR DESCRIPTION
Contributes to #13 .

Some simple `pandas` code was added as a placeholder. in the first PR setting up the CLI (#18).

That code is no longer necessary, and this PR removes it.