### PR TITLE
get options from pyproject.toml (fixes #24)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,3 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
-
-[tool.py-artifact-linter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,5 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.py-artifact-linter]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 click
+tomllib ; python_version < '3.11'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 click
-tomllib ; python_version < '3.11'
+tomli ; python_version < '3.11'

--- a/src/py_artifact_linter/_compat.py
+++ b/src/py_artifact_linter/_compat.py
@@ -1,0 +1,4 @@
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib

--- a/src/py_artifact_linter/cli.py
+++ b/src/py_artifact_linter/cli.py
@@ -1,50 +1,37 @@
 import os
 import click
-from dataclasses import dataclass
 from py_artifact_linter._compat import tomllib
 from py_artifact_linter.distribution_summary import summarize_distribution_contents
 
-from typing import Dict, Optional, Union
-
-
-@dataclass
-class _ConfigOptions:
-    summarize: _SummarizeOptions
-
-    @classmethod
-    def from_pyproject_file(cls, filepath: str):
-        with open(filepath, "rb") as f:
-            config_dict = tomllib.load(f)["tool"]["py-artifact-linter"]
-        return cls(
-            summarize=c
-        )
+from typing import Any, Dict, Optional, Union
 
 
 @click.group()
-@click.pass_context()
+@click.pass_context
 def cli(ctx):
     """Command group just used to group all others as sub-commands of ``py-artifact-linter``"""
     options: Dict[str, Union[int, str]] = {}
-    if os.exists("pyproject.toml"):
+    if os.path.exists("pyproject.toml"):
         with open("pyproject.toml", "rb") as f:
             config_dict = tomllib.load(f)
             options = config_dict.get("tool", {}).get("py-artifact-linter", {})
-    ctx.tool_options = options
-
+    ctx.obj = options
 
 
 @cli.command()
 @click.option(
     "--file", "-f", default=None, help="Source distribution (.tar.gz) to check"
 )
-@click.pass_tool_options
-def check(tool_options: Dict, file: str) -> None:
+@click.pass_obj
+def check(tool_options: Dict[str, Any], file: str) -> None:
     """
     Check the contents of a distribution.
     :param file: A file path.
     """
     print("running py-artifact-linter")
     print(file)
+    print("pyproject options")
+    print(tool_options)
 
 
 @cli.command()
@@ -52,7 +39,6 @@ def check(tool_options: Dict, file: str) -> None:
 @click.option(
     "--output-file", default=None, help="Path to a CSV file to write results to."
 )
-@click.pass_tool_options
-def summarize(tool_options: Dict, file: str, output_file: Optional[str]) -> None:
+def summarize(file: str, output_file: Optional[str]) -> None:
     """Print a summary of a distribution's contents"""
     summarize_distribution_contents(file=file, output_file=output_file)

--- a/src/py_artifact_linter/cli.py
+++ b/src/py_artifact_linter/cli.py
@@ -1,20 +1,44 @@
+import os
 import click
+from dataclasses import dataclass
+from py_artifact_linter._compat import tomllib
 from py_artifact_linter.distribution_summary import summarize_distribution_contents
 
-from typing import Optional
+from typing import Dict, Optional, Union
+
+
+@dataclass
+class _ConfigOptions:
+    summarize: _SummarizeOptions
+
+    @classmethod
+    def from_pyproject_file(cls, filepath: str):
+        with open(filepath, "rb") as f:
+            config_dict = tomllib.load(f)["tool"]["py-artifact-linter"]
+        return cls(
+            summarize=c
+        )
 
 
 @click.group()
-def cli():
+@click.pass_context()
+def cli(ctx):
     """Command group just used to group all others as sub-commands of ``py-artifact-linter``"""
-    pass
+    options: Dict[str, Union[int, str]] = {}
+    if os.exists("pyproject.toml"):
+        with open("pyproject.toml", "rb") as f:
+            config_dict = tomllib.load(f)
+            options = config_dict.get("tool", {}).get("py-artifact-linter", {})
+    ctx.tool_options = options
+
 
 
 @cli.command()
 @click.option(
     "--file", "-f", default=None, help="Source distribution (.tar.gz) to check"
 )
-def check(file: str) -> None:
+@click.pass_tool_options
+def check(tool_options: Dict, file: str) -> None:
     """
     Check the contents of a distribution.
     :param file: A file path.
@@ -28,6 +52,7 @@ def check(file: str) -> None:
 @click.option(
     "--output-file", default=None, help="Path to a CSV file to write results to."
 )
-def summarize(file: str, output_file: Optional[str]) -> None:
+@click.pass_tool_options
+def summarize(tool_options: Dict, file: str, output_file: Optional[str]) -> None:
     """Print a summary of a distribution's contents"""
     summarize_distribution_contents(file=file, output_file=output_file)


### PR DESCRIPTION
Fixes #24.

Adds preliminary support for parsing options from `pyproject.toml`. The project doesn't currently have any configuration that needs that, but such changes are coming.

```shell
make build install
py-artifact-linter check --file yeah
```