### PR TITLE
[ci] set black line length to 100

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 100

--- a/src/py_artifact_linter/cli.py
+++ b/src/py_artifact_linter/cli.py
@@ -19,9 +19,7 @@ def cli(ctx):
 
 
 @cli.command()
-@click.option(
-    "--file", "-f", default=None, help="Source distribution (.tar.gz) to check"
-)
+@click.option("--file", "-f", default=None, help="Source distribution (.tar.gz) to check")
 @click.pass_obj
 def check(tool_options: Dict[str, Any], file: str) -> None:
     """
@@ -36,9 +34,7 @@ def check(tool_options: Dict[str, Any], file: str) -> None:
 
 @cli.command()
 @click.option("--file", "-f", help="Source distribution (.tar.gz) to check")
-@click.option(
-    "--output-file", default=None, help="Path to a CSV file to write results to."
-)
+@click.option("--output-file", default=None, help="Path to a CSV file to write results to.")
 def summarize(file: str, output_file: Optional[str]) -> None:
     """Print a summary of a distribution's contents"""
     summarize_distribution_contents(file=file, output_file=output_file)

--- a/src/py_artifact_linter/distribution_summary.py
+++ b/src/py_artifact_linter/distribution_summary.py
@@ -70,9 +70,7 @@ def _get_zipfile_summary(file: str) -> _DistributionSummary:
     )
 
 
-def summarize_distribution_contents(
-    file: str, output_file: Optional[str] = None
-) -> None:
+def summarize_distribution_contents(file: str, output_file: Optional[str] = None) -> None:
     print(f"checking file '{file}'")
 
     if file.endswith("gz"):


### PR DESCRIPTION
Sets the line length for `black` explicitly, and to 100 characters.

It's personal preference. I get to pick so 😜 .

Also this shows an example of configuring something other than the build system in `pyproject.toml`, which is cool (for some definition of cool).